### PR TITLE
Add book links to endnotes

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -10,10 +10,10 @@
 			<h2 epub:type="title">Endnotes</h2>
 			<ol>
 				<li id="note-1" epub:type="endnote">
-					<p>See <i epub:type="se:name.publication.book">813</i>, by Maurice Leblanc, translated by Alexander Teixeira de Mattos. <a href="chapter-2.xhtml#noteref-1" epub:type="backlink">↩</a></p>
+					<p>See <i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/813/alexander-teixeira-de-mattos">813</a></i>, by Maurice Leblanc, translated by Alexander Teixeira de Mattos. <a href="chapter-2.xhtml#noteref-1" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-2" epub:type="endnote">
-					<p>See <i epub:type="se:name.publication.book">The Hollow Needle</i> by Maurice Leblanc, translated by Alexander Teixeira de Mattos, and later volumes of the Lupin series. <a href="chapter-3.xhtml#noteref-2" epub:type="backlink">↩</a></p>
+					<p>See <i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/the-hollow-needle/alexander-teixeira-de-mattos">The Hollow Needle</a></i> by Maurice Leblanc, translated by Alexander Teixeira de Mattos, and later volumes of the Lupin series. <a href="chapter-3.xhtml#noteref-2" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-3" epub:type="endnote">
 					<p>The name given to the brigands in the Vendée, who tortured their victims with fire to make them confess where their money was hidden. (Translator’s note) <a href="chapter-8.xhtml#noteref-3" epub:type="backlink">↩</a></p>
@@ -28,7 +28,7 @@
 					<p>The Cross of Lorraine is a cross with two horizontal lines or bars across the upper half of the perpendicular beam. (Translator’s note) <a href="chapter-11.xhtml#noteref-6" epub:type="backlink">↩</a></p>
 				</li>
 				<li id="note-7" epub:type="endnote">
-					<p>See <i epub:type="se:name.publication.book">The Confessions of Arsène Lupin</i> by Maurice Leblanc Translated by Alexander Teixeira de Mattos. <a href="chapter-13.xhtml#noteref-7" epub:type="backlink">↩</a></p>
+					<p>See <i epub:type="se:name.publication.book"><a href="https://standardebooks.org/ebooks/maurice-leblanc/the-confessions-of-arsene-lupin/alexander-teixeira-de-mattos">The Confessions of Arsène Lupin</a></i> by Maurice Leblanc Translated by Alexander Teixeira de Mattos. <a href="chapter-13.xhtml#noteref-7" epub:type="backlink">↩</a></p>
 				</li>
 			</ol>
 		</section>


### PR DESCRIPTION
As discussed in [another issue](https://github.com/standardebooks/maurice-leblanc_the-hollow-needle_alexander-teixeira-de-mattos/issues/2), this adds some links to the endnotes for titles that are available from Standard Ebooks.